### PR TITLE
bugfix/accurics_remediation_21844247655068205 - Auto Generated Pull Request From Accurics

### DIFF
--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -61,6 +61,7 @@ resource "aws_db_instance" "km_db" {
   tags = merge(var.default_tags, {
     Name = "km_db_${var.environment}"
   })
+  backup_retention_period = 30
 }
 
 resource "aws_ssm_parameter" "km_ssm_db_host" {


### PR DESCRIPTION
Creating point-in-time RDS instance snapshots periodically will allow you to handle efficiently your data restoration process in the event of a user error on the source database or to save data before making a major change to the instance database such as changing the structure of a table.