### PR TITLE
bugfix/accurics_remediation_29909920850838834 - Auto Generated Pull Request From Accurics

### DIFF
--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -47,7 +47,7 @@ resource "aws_db_instance" "km_db" {
   allocated_storage         = 20
   engine                    = "postgres"
   engine_version            = "10.6"
-  instance_class            = "db.t3.medium"
+  instance_class            = "db.m5.xlarge"
   storage_type              = "gp2"
   password                  = var.db_password
   username                  = var.db_username


### PR DESCRIPTION
Ensure the following values are set as per the company standard - DB Instance type: db.m5.xlarge, Allocated Storage: 200 G, Max Allocated storage: 500 G, Performance Insights Enabled: True, Enhanced monitoring: True.