### PR TITLE
bugfix/accurics_remediation_8050739554792412 - Auto Generated Pull Request From Accurics

### DIFF
--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -20,7 +20,7 @@ resource "aws_security_group" "km_rds_sg" {
     from_port   = 5432
     to_port     = 5432
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = ["<cidr>"]
   }
 
   # outbound internet access


### PR DESCRIPTION
Limit the access scope for 'Postgres SQL' to only allow access in internal networks and limited scope. If public interface exists, remove it and limit the access scope within the VPC only to applications or instances that requires access. Amazon Reference: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/authorizing-access-to-an-instance.html. As a further protection step, Use 'Tamper Protection' (Full Protection mode) and region lock to prevent unauthorized changes to network access settings, refer to /360003963194#Set_an_AWS_Security_Group_to_Full_Protection for more details.