### PR TITLE
bugfix/accurics_remediation_3814273910985455 - Auto Generated Pull Request From Accurics

### DIFF
--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -111,6 +111,10 @@ resource "aws_s3_bucket" "km_blob_storage" {
 
 resource "aws_s3_bucket" "km_public_blob" {
   bucket = "km-public-blob"
+
+  versioning {
+    enabled = true
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "km_public_blob" {


### PR DESCRIPTION
You can use versioning to preserve, retrieve, and restore every version of every object stored in your Amazon S3 bucket. With versioning, you can easily recover from both unintended user actions and application failures. When you enable versioning for a bucket, if Amazon S3 receives multiple write requests for the same object simultaneously, it stores all of the objects.