### PR TITLE
bugfix/accurics_remediation_14769010122261683 - Auto Generated Pull Request From Accurics

### DIFF
--- a/modules/compute/main.tf
+++ b/modules/compute/main.tf
@@ -27,7 +27,7 @@ resource "aws_iam_role" "km_ecs_task_execution_role" {
 EOF
 
   tags = merge(var.default_tags, {
-    name        = "km_ecs_task_execution_role_${var.environment}"
+    name = "km_ecs_task_execution_role_${var.environment}"
   })
 }
 
@@ -106,7 +106,7 @@ resource "aws_ecs_service" "km_ecs_service" {
   network_configuration {
     assign_public_ip = true
     subnets          = var.private_subnet
-    security_groups  = [ var.elb_sg ]
+    security_groups  = [var.elb_sg]
   }
   tags = merge(var.default_tags, {
   })
@@ -114,18 +114,18 @@ resource "aws_ecs_service" "km_ecs_service" {
 
 resource "aws_cloudwatch_log_group" "km_log_group" {
   name              = "km_log_group_${var.environment}"
-  retention_in_days = 1
+  retention_in_days = 120
 
   tags = merge(var.default_tags, {
     Name = "km_log_group_${var.environment}"
   })
 }
 
-resource "aws_instance" "km_vm"{
-  ami = data.aws_ami.ubuntu_ami.id
-  instance_type = "t2.micro"
-  vpc_security_group_ids = [ var.elb_sg ]
-  subnet_id = var.public_subnet[0]
+resource "aws_instance" "km_vm" {
+  ami                    = data.aws_ami.ubuntu_ami.id
+  instance_type          = "t2.micro"
+  vpc_security_group_ids = [var.elb_sg]
+  subnet_id              = var.public_subnet[0]
   tags = merge(var.default_tags, {
     Name = "km_vm_${var.environment}"
   })


### PR DESCRIPTION
Ensure that your AWS CloudWatch Log Group has the retention period of at least 90 days in order to establish how long log events are kept in AWS CloudWatch Logs. Just like metric filters, retention settings are assigned to CloudWatch Log Groups and the retention period assigned to a log group is applied to their log streams as well. Note: This policy requires that retention policy is set for AWS CloudWatch Log Group.