### PR TITLE
bugfix/accurics_remediation_3378273102479379 - Auto Generated Pull Request From Accurics

### DIFF
--- a/modules/compute/main.tf
+++ b/modules/compute/main.tf
@@ -27,7 +27,7 @@ resource "aws_iam_role" "km_ecs_task_execution_role" {
 EOF
 
   tags = merge(var.default_tags, {
-    name        = "km_ecs_task_execution_role_${var.environment}"
+    name = "km_ecs_task_execution_role_${var.environment}"
   })
 }
 
@@ -106,7 +106,7 @@ resource "aws_ecs_service" "km_ecs_service" {
   network_configuration {
     assign_public_ip = true
     subnets          = var.private_subnet
-    security_groups  = [ var.elb_sg ]
+    security_groups  = [var.elb_sg]
   }
   tags = merge(var.default_tags, {
   })
@@ -119,13 +119,15 @@ resource "aws_cloudwatch_log_group" "km_log_group" {
   tags = merge(var.default_tags, {
     Name = "km_log_group_${var.environment}"
   })
+
+  kms_key_id = "<kms_key_id>"
 }
 
-resource "aws_instance" "km_vm"{
-  ami = data.aws_ami.ubuntu_ami.id
-  instance_type = "t2.micro"
-  vpc_security_group_ids = [ var.elb_sg ]
-  subnet_id = var.public_subnet[0]
+resource "aws_instance" "km_vm" {
+  ami                    = data.aws_ami.ubuntu_ami.id
+  instance_type          = "t2.micro"
+  vpc_security_group_ids = [var.elb_sg]
+  subnet_id              = var.public_subnet[0]
   tags = merge(var.default_tags, {
     Name = "km_vm_${var.environment}"
   })


### PR DESCRIPTION
Log group data is always encrypted in CloudWatch Logs. You can optionally use AWS Key Management Service for this encryption. If you do, the encryption is done using an AWS KMS customer master key (CMK). Encryption using AWS KMS is enabled at the log group level, by associating a CMK with a log group, either when you create the log group or after it exists.