### PR TITLE
bugfix/accurics_remediation_9181297262559345 - Auto Generated Pull Request From Accurics

### DIFF
--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -117,5 +117,5 @@ resource "aws_s3_bucket_public_access_block" "km_public_blob" {
   bucket = aws_s3_bucket.km_public_blob.id
 
   block_public_acls   = false
-  block_public_policy = false
+  block_public_policy = true
 }


### PR DESCRIPTION
Using Amazon S3 Block Public Access as a centralized way to limit public access. Block Public Access settings override bucket policies and object permissions. Be sure to enable Block Public Access for all accounts and buckets that you don't want publicly accessible.